### PR TITLE
Update FileCallbackResult.cs

### DIFF
--- a/Example/src/WebApplication/FileCallbackResult.cs
+++ b/Example/src/WebApplication/FileCallbackResult.cs
@@ -41,7 +41,7 @@ namespace WebApplication
             public Task ExecuteAsync(ActionContext context, FileCallbackResult result)
             {
                 SetHeadersAndLog(context, result, fileLength: null, enableRangeProcessing: false);
-                return result._callback(context.HttpContext.Response.Body, context);
+                return result._callback(context.HttpContext.Response.BodyWriter.AsStream(), context);
             }
         }
     }


### PR DESCRIPTION
A smol' MR changing the stream passed to the callback:
- from the "Response Body Stream" 
- to the "Response Body Writer property as a stream" 
as the former could trigger "Synchronous operations are disallowed" exceptions with Kestrel (and one doesn't necessarily wanna enable that support).